### PR TITLE
Fix OpenAI embeddings sending null for optional fields

### DIFF
--- a/src/Langchain/Embeddings/OpenAI.hs
+++ b/src/Langchain/Embeddings/OpenAI.hs
@@ -87,12 +87,14 @@ instance ToJSON EmbeddingsInput where
 
 instance ToJSON OpenAIEmbeddingsRequest where
   toJSON OpenAIEmbeddingsRequest {..} =
-    object
+    object $
       [ "input" .= inputReq
       , "model" .= modelReq
-      , "dimensions" .= dimensionsReq
-      , "encoding_format" .= encodingFormatReq
       ]
+        ++ catMaybes
+          [ ("dimensions" .=) <$> dimensionsReq
+          , ("encoding_format" .=) <$> encodingFormatReq
+          ]
 
 -- Response
 data EmbeddingsUsage = EmbeddingsUsage


### PR DESCRIPTION
- The `ToJSON` instance for `OpenAIEmbeddingsRequest` sends `"dimensions": null` and `"encoding_format": null` when those fields are `Nothing`
- OpenAI's API rejects null values for these optional fields with a 400 error: `'$.input' is invalid`
- Fix: omit these fields from the JSON payload entirely when not set, using `catMaybes`

## Reproduction

Using `defaultOpenAIEmbeddings` (where `dimensions = Nothing` and `encodingFormat = Nothing`), embedding requests fail with:

```
API error: 400 "{\n  \"error\": {\n    \"message\": \"'$.input' is invalid. Please check the API reference: https://platform.openai.com/docs/api-reference.\",\n    ...
```

The misleading `$.input` error message is because OpenAI's validation fails on the null fields before properly reporting which field is invalid.

## Fix

```haskell
-- Before: sends "dimensions": null, "encoding_format": null
object
  [ "input" .= inputReq
  , "model" .= modelReq
  , "dimensions" .= dimensionsReq
  , "encoding_format" .= encodingFormatReq
  ]

-- After: omits fields when Nothing
object $
  [ "input" .= inputReq
  , "model" .= modelReq
  ]
    ++ catMaybes
      [ ("dimensions" .=) <$> dimensionsReq
      , ("encoding_format" .=) <$> encodingFormatReq
      ]
```